### PR TITLE
feat(es): add Mexican Spanish (es_MX) G2P normalization + es_MX-ald-medium teacher

### DIFF
--- a/configs/roota-piper-teachers.example.json
+++ b/configs/roota-piper-teachers.example.json
@@ -155,6 +155,25 @@
       "model_md5": "40cdb7930ff91b81574d5f0489e076ea",
       "config_md5": "1fda3ec1d0d3a5a74064397ea8fe0af0",
       "role": "primary Chinese teacher"
+    },
+    "es_MX_ald_medium": {
+      "status": "downloaded",
+      "language": "Spanish",
+      "language_code": "es_MX",
+      "voice_key": "es_MX-ald-medium",
+      "quality": "medium",
+      "num_speakers": 1,
+      "phoneme_type": "espeak",
+      "espeak_voice": "es-419",
+      "sample_rate": 22050,
+      "phoneme_id_count": 154,
+      "model_path": "${PIPER_VOICES}/es/es_MX/ald/medium/es_MX-ald-medium.onnx",
+      "config_path": "${PIPER_VOICES}/es/es_MX/ald/medium/es_MX-ald-medium.onnx.json",
+      "model_relpath": "es/es_MX/ald/medium/es_MX-ald-medium.onnx",
+      "config_relpath": "es/es_MX/ald/medium/es_MX-ald-medium.onnx.json",
+      "model_size_bytes": 63201294,
+      "config_size_bytes": 4878,
+      "role": "Mexican Spanish teacher (es_MX); espeak voice es-419 (Latin American phonemes). Use with mexican_g2p_normalizer.py for toponym/number corrections."
     }
   }
 }

--- a/tools/build_piper_vits_roota_probe_pack.py
+++ b/tools/build_piper_vits_roota_probe_pack.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import argparse
 import json
 import math
+import re
 import statistics
 import sys
 import wave
@@ -27,6 +28,7 @@ import onnx
 import onnxruntime as ort
 from onnx import TensorProto, helper
 from piper.voice import PiperVoice
+from mexican_g2p_normalizer import normalize_mexican_g2p
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -85,6 +87,9 @@ FULL_LOGICAL_OUTPUTS = (
     "generator_conv_pre",
     "generator_first_upsample",
 )
+
+
+
 
 
 def parse_args() -> argparse.Namespace:
@@ -626,7 +631,8 @@ def build_pack(args: argparse.Namespace) -> dict[str, Any]:
     with manifest_path.open("w", encoding="utf-8") as out:
         for index, row in enumerate(rows, start=1):
             row_id = safe_row_id(index, int(row["_line_no"]))
-            text = str(row.get("target_text") or row.get("text") or "").strip()
+            raw_text = str(row.get("target_text") or row.get("text") or "").strip()
+            text = normalize_mexican_g2p(raw_text)
             sentence_phonemes = voice.phonemize(text)
             if not sentence_phonemes:
                 raise RuntimeError(f"{row_id}: Piper produced no sentence phonemes")

--- a/tools/mexican_g2p_normalizer.py
+++ b/tools/mexican_g2p_normalizer.py
@@ -1,0 +1,82 @@
+"""Shared Mexican-Spanish pre-phonemization normalizer for espeak-ng.
+
+Used by BOTH the serve dashboard and the pack builder so the model learns and
+pronounces these cases the same way. espeak-ng (the G2P that both the Piper
+teacher and the students use) lacks Mexican indigenous toponym/number rules, so
+we rewrite the text before phonemization:
+
+Toponyms (Nahuatl 'x'):
+    Oaxaca->Oajaca  Xalapa->Jalapa  Tlaxcala->Tlaskala  Mixteca->Misteka
+    Huastec->Guastec  Texcoco->Tescoco
+Numbers (es-419 reads ',' as decimal, '.' as thousands):
+    strip comma-thousands ('12,500'->'12500'), billion scale -> 'X millones',
+    leading '-' -> 'menos', '$X.YY' -> 'X pesos con YY centavos',
+    phone-like space groups -> digit-by-digit, 'm²'->'metros cuadrados'.
+"""
+
+from __future__ import annotations
+
+import re
+
+
+def _replace_number_group(match: re.Match) -> str:
+    """'12,500' -> '12500'; billion scale -> '<value/1e6> millones'."""
+    digits = match.group(0).replace(",", "")
+    n = int(digits)
+    if n >= 1_000_000_000:
+        return f"{n // 1_000_000} millones"
+    return digits
+
+
+def _currency(match: re.Match) -> str:
+    """'$1,850.75' -> '1850 pesos con 75 centavos'; '$12,500' -> '12500 pesos'."""
+    raw = match.group(1)
+    digits = re.sub(r"\b\d{1,3}(?:,\d{3})+\b", lambda m: m.group(0).replace(",", ""), raw)
+    if "." in digits:
+        whole, frac = digits.split(".", 1)
+        centavos = re.sub(r"\D", "", frac)[:2]
+        if centavos:
+            return f"{whole} pesos con {centavos} centavos"
+        return f"{whole} pesos"
+    return f"{digits} pesos"
+
+
+def _phone(match: re.Match) -> str:
+    """'55 5489 2726' -> '5 5 5 4 8 9 2 7 2 6' (read digit-by-digit)."""
+    return " ".join(re.sub(r"\s+", "", match.group(0)))
+
+
+def normalize_mexican_g2p(text: str) -> str:
+    """Pre-phonemization normalization for Mexican Spanish with espeak-ng."""
+    text = re.sub(r"\bOaxaca\b", "Oajaca", text)
+    text = re.sub(r"\boaxaca\b", "oajaca", text)
+    text = re.sub(r"\bOaxaqueñ", "Oajaqueñ", text)
+    text = re.sub(r"\boaxaqueñ", "oajaqueñ", text)
+    text = re.sub(r"\bXalapa\b", "Jalapa", text)
+    text = re.sub(r"\bxalapa\b", "jalapa", text)
+    text = re.sub(r"\bXalapeñ", "Jalapeñ", text)
+    text = re.sub(r"\bxalapeñ", "jalapeñ", text)
+    text = re.sub(r"\bTlaxcala\b", "Tlaskala", text)
+    text = re.sub(r"\btlaxcala\b", "tlaskala", text)
+    text = re.sub(r"\bMixteca\b", "Misteka", text)
+    text = re.sub(r"\bmixteca\b", "misteka", text)
+    text = re.sub(r"\bHuastec", "Guastec", text)
+    text = re.sub(r"\bhuastec", "guastec", text)
+    text = re.sub(r"\bTexcoco\b", "Tescoco", text)
+    text = re.sub(r"\btexcoco\b", "tescoco", text)
+    # negative numbers
+    text = re.sub(r"(?<![\w-])-(\d)", r"menos \1", text)
+    # currency
+    text = re.sub(r"\$(\d[\d.,]*)", _currency, text)
+    # phone-like space-separated digit groups -> digit-by-digit
+    text = re.sub(r"\b\d{1,4}(?: \d{1,4}){2,}\b", _phone, text)
+    # units (espeak reads the superscript "²"/"³" as 'dos'/'tres')
+    text = re.sub(r"\bkm\s?²\b", "kilómetros cuadrados", text, flags=re.I)
+    text = re.sub(r"\bkm\s?³\b", "kilómetros cúbicos", text, flags=re.I)
+    text = re.sub(r"\bcm\s?²\b", "centímetros cuadrados", text, flags=re.I)
+    text = re.sub(r"\bcm\s?³\b", "centímetros cúbicos", text, flags=re.I)
+    text = re.sub(r"\bm\s?²\b", "metros cuadrados", text, flags=re.I)
+    text = re.sub(r"\bm\s?³\b", "metros cúbicos", text, flags=re.I)
+    # comma-thousands + billions
+    text = re.sub(r"\b\d{1,3}(?:,\d{3})+\b", _replace_number_group, text)
+    return text

--- a/tools/serve_roota_arbitrary_tts_dashboard.py
+++ b/tools/serve_roota_arbitrary_tts_dashboard.py
@@ -31,6 +31,7 @@ import numpy as np
 import onnxruntime as ort
 import torch
 from scipy.signal import butter, sosfiltfilt
+from mexican_g2p_normalizer import normalize_mexican_g2p
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -166,6 +167,9 @@ def split_text_for_phonemizer(text: str, mode: str) -> list[str]:
             raise ValueError("text is empty")
         return [stripped]
     return chunks
+
+
+# (normalización mexicana movida a mexican_g2p_normalizer.py) 
 
 
 def require_file(path: Path, label: str) -> None:
@@ -575,6 +579,7 @@ class DashboardState:
         started = time.time()
         render_id = f"{int(started)}-{uuid.uuid4().hex[:8]}"
         text_chunking = str(getattr(self.args, "text_chunking", "none"))
+        clean_text = normalize_mexican_g2p(clean_text)
         text_chunks = split_text_for_phonemizer(clean_text, text_chunking)
         phoneme_chunks: list[tuple[str, list[Any]]] = []
         for text_chunk in text_chunks:


### PR DESCRIPTION
## feat(es): Mexican Spanish (es_MX) G2P normalization + es_MX-ald-medium teacher

### Summary
Adds a Mexican Spanish pre-phonemization normalizer and registers the
`es_MX-ald-medium` Piper teacher, so the language-porting recipe can
distill a genuinely Mexican-Spanish voice (espeak voice `es-419`).

espeak-ng (the G2P both the Piper teacher and the students use) lacks
Mexican indigenous toponym and number rules:
- `Oaxaca` is read `/oaksaka/` (ks) instead of `/oa'xaka/` (the "x" in Nahuatl
  toponyms is /s/ or /x/, not /ks/).
- Numbers written `12,500` are read `doce coma quinientos` because es-419
  uses `,` for decimals and `.` for thousands.
- `$1,850.75` is read as `dólar ... punto ...` instead of
  `mil ochocientos cincuenta pesos con setenta y cinco centavos`.

### What's added
- **`tools/mexican_g2p_normalizer.py`** — a shared `normalize_mexican_g2p()`
  applied before phonemization. It rewrites:
  - Toponyms with a Nahuatl `x`: Oaxaca→Oajaca, Xalapa→Jalapa,
    Tlaxcala→Tlaskala, Mixteca→Misteka, Huastec→Guastec, Texcoco→Tescoco.
  - Numbers: comma-thousands → digits (`12,500`→`12500`), billion scale →
    `X millones` (`1,500,000,000`→`1500 millones`), leading `-` → `menos`,
    `$X.YY` → `X pesos con YY centavos`, phone-like space groups →
    digit-by-digit, `m²` → `metros cuadrados`.
- Wires the normalizer into:
  - **`tools/serve_roota_arbitrary_tts_dashboard.py`** (live demo).
  - **`tools/build_piper_vits_roota_probe_pack.py`** (so the distilled model
    learns the corrected phonemes, not just the dashboard).
- **`configs/roota-piper-teachers.example.json`** — registers the
  `es_MX-ald-medium` teacher (medium quality, espeak voice `es-419`,
  154 phonemes, 22050 Hz).

### Notes
- `es_MX-ald-medium` is a Piper voice (MIT) from `rhasspy/piper-voices`.
- The normalizer is a pre-G2P text layer; the model itself is unchanged.
- Related but separate PR: missing pipeline files in the published repo
  (`src/saanotts/models/__init__.py` nirmal_tts guard, `tools/qat_ste.py`,
  `train_roota_joint_c_finetune.py`).