### PR TITLE
fix: make pipeline runnable (nirmal_tts guard, qat_ste, joint_common)

### DIFF
--- a/src/saanotts/models/__init__.py
+++ b/src/saanotts/models/__init__.py
@@ -43,28 +43,35 @@ from saanotts.models.widebasis_vocoder import WideBasisBlock
 from saanotts.models.widebasis_vocoder import WideBasisVocoder
 from saanotts.models.widebasis_vocoder import WideBasisVocoderConfig
 from saanotts.models.widebasis_vocoder import widebasis_parameter_breakdown
-from saanotts.models.nirmal_tts import NirmalAdaptiveMidbandEnhancer
-from saanotts.models.nirmal_tts import NirmalConfig
-from saanotts.models.nirmal_tts import NirmalDecoderOutput
-from saanotts.models.nirmal_tts import NirmalFrameDeterministicPosteriorEncoder
-from saanotts.models.nirmal_tts import NirmalFrameDeterministicTextPrior
-from saanotts.models.nirmal_tts import NirmalFrameDeterministicTTS
-from saanotts.models.nirmal_tts import NirmalFrameNormalizedPosteriorEncoder
-from saanotts.models.nirmal_tts import NirmalFrameNormalizedTextPrior
-from saanotts.models.nirmal_tts import NirmalFrameNormalizedTTS
-from saanotts.models.nirmal_tts import NirmalGrainDecoder
-from saanotts.models.nirmal_tts import NirmalWaveDecoder
-from saanotts.models.nirmal_tts import NirmalPosteriorEncoder
-from saanotts.models.nirmal_tts import NirmalTTS
-from saanotts.models.nirmal_tts import NirmalTextPrior
-from saanotts.models.nirmal_tts import adjacent_grain_seam_loss
-from saanotts.models.nirmal_tts import estimate_inference_macs_per_second
-from saanotts.models.nirmal_tts import extract_overlapping_grains
-from saanotts.models.nirmal_tts import nirmal_parameter_breakdown
-from saanotts.models.nirmal_tts import nirmal_adaptive_midband_parameter_breakdown
-from saanotts.models.nirmal_tts import nirmal_frame_deterministic_parameter_breakdown
-from saanotts.models.nirmal_tts import nirmal_frame_normalized_parameter_breakdown
-from saanotts.models.nirmal_tts import normalized_overlap_add
+# The published repo does not ship src/saanotts/models/nirmal_tts.py (verified:
+# not tracked in git, not present). Guard the imports so the package loads and
+# any present module (e.g. fsd, needed by the decoder trainer) is importable.
+# Get the real nirmal_tts.py from the author to re-enable these symbols.
+try:
+    from saanotts.models.nirmal_tts import NirmalAdaptiveMidbandEnhancer
+    from saanotts.models.nirmal_tts import NirmalConfig
+    from saanotts.models.nirmal_tts import NirmalDecoderOutput
+    from saanotts.models.nirmal_tts import NirmalFrameDeterministicPosteriorEncoder
+    from saanotts.models.nirmal_tts import NirmalFrameDeterministicTextPrior
+    from saanotts.models.nirmal_tts import NirmalFrameDeterministicTTS
+    from saanotts.models.nirmal_tts import NirmalFrameNormalizedPosteriorEncoder
+    from saanotts.models.nirmal_tts import NirmalFrameNormalizedTextPrior
+    from saanotts.models.nirmal_tts import NirmalFrameNormalizedTTS
+    from saanotts.models.nirmal_tts import NirmalGrainDecoder
+    from saanotts.models.nirmal_tts import NirmalWaveDecoder
+    from saanotts.models.nirmal_tts import NirmalPosteriorEncoder
+    from saanotts.models.nirmal_tts import NirmalTTS
+    from saanotts.models.nirmal_tts import NirmalTextPrior
+    from saanotts.models.nirmal_tts import adjacent_grain_seam_loss
+    from saanotts.models.nirmal_tts import estimate_inference_macs_per_second
+    from saanotts.models.nirmal_tts import extract_overlapping_grains
+    from saanotts.models.nirmal_tts import nirmal_parameter_breakdown
+    from saanotts.models.nirmal_tts import nirmal_adaptive_midband_parameter_breakdown
+    from saanotts.models.nirmal_tts import nirmal_frame_deterministic_parameter_breakdown
+    from saanotts.models.nirmal_tts import nirmal_frame_normalized_parameter_breakdown
+    from saanotts.models.nirmal_tts import normalized_overlap_add
+except ModuleNotFoundError:  # pragma: no cover - upstream tree omits nirmal_tts
+    pass
 
 __all__ = [
     "HOP_LENGTH",
@@ -133,3 +140,7 @@ __all__ = [
     "nirmal_frame_normalized_parameter_breakdown",
     "normalized_overlap_add",
 ]
+
+# Drop any names that failed to import (e.g. the nirmal_* symbols when
+# nirmal_tts.py is absent), so `from saanotts.models import *` never raises.
+__all__ = [n for n in __all__ if n in globals()]

--- a/tools/qat_ste.py
+++ b/tools/qat_ste.py
@@ -1,0 +1,25 @@
+"""Minimal stand-in for the author's tools/qat_ste.py (quantization-aware training).
+
+The upstream repo publishes train_roota_piper_latent_student.py which does
+`import qat_ste` and calls `qat_ste.enable_dense_conv1d_qat(model)`, but that
+file is NOT committed to GitHub (verified: not tracked in git, not present in
+tools/). This stub lets the latent trainer import and run.
+
+NOTE: this disables quantization-awareness (it is a no-op). For a production
+voice you should obtain the real tools/qat_ste.py from the author and replace
+this file; the final int8 export/golden-gate may depend on real STE behavior.
+"""
+
+from __future__ import annotations
+
+import torch  # noqa: F401  (kept so the module feels like the original)
+
+
+def enable_dense_conv1d_qat(model):
+    """No-op wrapper: returns the model unchanged (no QAT).
+
+    Upstream returns the model wrapped with per-channel int8 straight-through
+    estimation. For measuring throughput / a first training run a no-op is
+    sufficient; quality runs should use the real implementation.
+    """
+    return model

--- a/tools/train_roota_joint_c_finetune.py
+++ b/tools/train_roota_joint_c_finetune.py
@@ -1,0 +1,269 @@
+"""Shared helpers for the joint z finetune (reconstructed joint_common).
+
+The published repo ships train_roota_joint_z_finetune.py which does
+`import train_roota_joint_c_finetune as joint_common`, but that module is NOT in
+GitHub (verified). This reconstruction provides the names z_finetune needs by
+delegating to the two trainer modules that ARE present and complete:
+
+    train_roota_piper_decoder_student  (DecoderStudent, MultiPeriodDiscriminator,
+                                        adversarial loss helpers, ChunkSample)
+    train_roota_piper_latent_student   (create_model_from_config, expand_features,
+                                        predict_latent_tensor, load checkpoint)
+
+The two adversarial runners rebuild the exact inline logic from the decoder
+trainer's training loop (target_energy_gate + LSGAN losses + gate/quantile).
+"""
+
+from __future__ import annotations
+
+import argparse
+import inspect
+import json
+import math
+import random
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import torch
+from torch import nn  # noqa: F401  (kept for parity with the upstream module)
+
+import train_roota_piper_decoder_student as decoder_trainer
+import train_roota_piper_latent_student as latent_trainer
+
+
+# --------------------------------------------------------------------------
+# trivial utils
+# --------------------------------------------------------------------------
+def require_dir(path: Path | str, label: str) -> None:
+    p = Path(path)
+    if not p.is_dir():
+        raise FileNotFoundError(f"{label} not found: {p}")
+
+
+def require_file(path: Path | str, label: str) -> None:
+    decoder_trainer.require_file(path, label)
+
+
+def pick_device(requested: str) -> torch.device:
+    return decoder_trainer.pick_device(requested)
+
+
+def finite_or_raise(value: torch.Tensor | float, label: str, step: int) -> None:
+    v = float(value.detach().cpu()) if hasattr(value, "detach") else float(value)
+    if not math.isfinite(v):
+        raise RuntimeError(f"non-finite {label} at step {step}")
+
+
+def jsonable_args(args: argparse.Namespace) -> dict[str, Any]:
+    out: dict[str, Any] = {}
+    for k, v in vars(args).items():
+        if isinstance(v, Path):
+            out[k] = str(v)
+        elif isinstance(v, (list, tuple)) and v and isinstance(v[0], Path):
+            out[k] = [str(x) for x in v]
+        elif isinstance(v, (int, float, str, bool)) or v is None:
+            out[k] = v
+        else:
+            out[k] = str(v)
+    return out
+
+
+def state_dict_cpu(model: nn.Module) -> dict[str, torch.Tensor]:
+    return {k: v.detach().cpu() for k, v in model.state_dict().items()}
+
+
+# --------------------------------------------------------------------------
+# model building
+# --------------------------------------------------------------------------
+_DECODER_PARAMS = set(
+    inspect.signature(decoder_trainer.DecoderStudent.__init__).parameters
+) - {"self"}
+
+
+def decoder_from_config(config: dict[str, Any]) -> decoder_trainer.DecoderStudent:
+    """Build a DecoderStudent from a checkpoint 'config' dict (list->tuple)."""
+    kwargs: dict[str, Any] = {}
+    for k, v in config.items():
+        if k not in _DECODER_PARAMS:
+            continue
+        if isinstance(v, list):
+            v = tuple(v)
+        kwargs[k] = v
+    return decoder_trainer.DecoderStudent(**kwargs)
+
+
+def load_acoustic_checkpoint(
+    checkpoint_path: Path,
+    device: torch.device,
+) -> tuple[nn.Module, dict[str, Any]]:
+    return latent_trainer.load_model_from_checkpoint(checkpoint_path, device)
+
+
+# --------------------------------------------------------------------------
+# acoustic shim: bridge a decoder ChunkSample to latent_trainer.expand_features
+# --------------------------------------------------------------------------
+class _AcousticShim:
+    def __init__(self, sample: decoder_trainer.ChunkSample, frames: int) -> None:
+        self.row_id = sample.row_id
+        self.chunk_index = sample.chunk_index
+        self.phoneme_ids = sample.phoneme_ids
+        self.durations = sample.durations
+        # expand_features only reads target.shape[0] (length contract); values unused.
+        self.target = np.zeros((frames,), dtype=np.float32)
+        self.latent = sample.latent
+
+
+def make_acoustic_shim(sample: decoder_trainer.ChunkSample, code_dim: int) -> _AcousticShim:
+    frames = int(sample.latent.shape[-1])
+    return _AcousticShim(sample, frames)
+
+
+# --------------------------------------------------------------------------
+# random crops
+# --------------------------------------------------------------------------
+@dataclass
+class _Crop:
+    sample: decoder_trainer.ChunkSample
+    start: int
+    end: int
+
+
+def select_crops(
+    samples: list[decoder_trainer.ChunkSample],
+    *,
+    batch_size: int,
+    crop_frames: int,
+) -> list[_Crop]:
+    # The joint finetune stacks crops of a fixed width, so only sample chunks
+    # that are at least crop_frames long (matching the acoustic model's latent
+    # frame count) are eligible; short chunks would yield a ragged crop.
+    eligible = [s for s in samples if int(s.latent.shape[-1]) >= crop_frames]
+    if not eligible:
+        raise RuntimeError(f"no samples with at least {crop_frames} frames")
+    crops: list[_Crop] = []
+    for _ in range(batch_size):
+        sample = eligible[random.randrange(len(eligible))]
+        nframes = int(sample.latent.shape[-1])
+        max_start = int(nframes) - int(crop_frames)
+        start = random.randint(0, max_start)
+        crops.append(_Crop(sample=sample, start=start, end=start + crop_frames))
+    return crops
+
+
+# --------------------------------------------------------------------------
+# adversarial runners (reconstructed from the decoder trainer inline loop)
+# --------------------------------------------------------------------------
+def run_waveform_adversarial(
+    *,
+    args: argparse.Namespace,
+    step: int,
+    discriminator: nn.Module | None,
+    discriminator_optimizer: torch.optim.Optimizer | None,
+    prediction: torch.Tensor,
+    target: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, float, float]:
+    gen = prediction.new_tensor(0.0)
+    feat = prediction.new_tensor(0.0)
+    disc = prediction.new_tensor(0.0)
+    gate_mean = 1.0
+    grad_norm = 0.0
+    if discriminator is not None and discriminator_optimizer is not None and step >= int(args.adv_start_step):
+        disc_pred = prediction
+        disc_target = target.detach()
+        if getattr(args, "adv_gate_mode", "target-energy") == "target-energy":
+            gate = decoder_trainer.target_energy_gate(
+                target,
+                quantile=float(args.adv_gate_quantile),
+                sharpness=float(args.adv_gate_sharpness),
+                frame_size=int(args.adv_gate_frame_size),
+                frame_hop=int(args.adv_gate_frame_hop),
+            )
+            gate_mean = float(gate.detach().mean().cpu())
+            disc_pred = prediction * gate
+            disc_target = disc_target * gate.detach()
+        decoder_trainer.set_requires_grad(discriminator, True)
+        discriminator_optimizer.zero_grad(set_to_none=True)
+        real_scores, _real_features = discriminator(disc_target)
+        fake_scores, _fake_features = discriminator(disc_pred.detach())
+        disc = decoder_trainer.discriminator_lsgan_loss(real_scores, fake_scores)
+        if not torch.isfinite(disc):
+            raise RuntimeError(f"non-finite discriminator loss at step {step}")
+        disc.backward()
+        grad_norm = float(
+            torch.nn.utils.clip_grad_norm_(discriminator.parameters(), max_norm=5.0).detach().cpu()
+        )
+        discriminator_optimizer.step()
+
+        decoder_trainer.set_requires_grad(discriminator, False)
+        fake_scores_for_gen, fake_features_for_gen = discriminator(disc_pred)
+        _real_scores_for_gen, real_features_for_gen = discriminator(disc_target)
+        gen = decoder_trainer.generator_lsgan_loss(fake_scores_for_gen)
+        feat = decoder_trainer.discriminator_feature_matching_loss(
+            real_features_for_gen,
+            fake_features_for_gen,
+        )
+        decoder_trainer.set_requires_grad(discriminator, True)
+        if not torch.isfinite(gen):
+            raise RuntimeError(f"non-finite generator adversarial loss at step {step}")
+        if not torch.isfinite(feat):
+            raise RuntimeError(f"non-finite adversarial feature loss at step {step}")
+    return gen, feat, disc, gate_mean, grad_norm
+
+
+def run_delta_adversarial(
+    *,
+    args: argparse.Namespace,
+    step: int,
+    discriminator: nn.Module | None,
+    discriminator_optimizer: torch.optim.Optimizer | None,
+    prediction: torch.Tensor,
+    target: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, float, float]:
+    gen = prediction.new_tensor(0.0)
+    feat = prediction.new_tensor(0.0)
+    disc = prediction.new_tensor(0.0)
+    gate_mean = 1.0
+    grad_norm = 0.0
+    if discriminator is not None and discriminator_optimizer is not None and step >= int(args.adv_start_step):
+        delta_gate = None
+        if getattr(args, "adv_gate_mode", "target-energy") == "target-energy":
+            delta_gate = decoder_trainer.target_energy_gate(
+                target,
+                quantile=float(args.adv_gate_quantile),
+                sharpness=float(args.adv_gate_sharpness),
+                frame_size=int(args.adv_gate_frame_size),
+                frame_hop=int(args.adv_gate_frame_hop),
+            )
+            gate_mean = float(delta_gate.detach().mean().cpu())
+        delta_prediction, delta_target = decoder_trainer.first_difference_discriminator_audio(
+            prediction, target, delta_gate
+        )
+        decoder_trainer.set_requires_grad(discriminator, True)
+        discriminator_optimizer.zero_grad(set_to_none=True)
+        real_scores, _real_features = discriminator(delta_target)
+        fake_scores, _fake_features = discriminator(delta_prediction.detach())
+        disc = decoder_trainer.discriminator_lsgan_loss(real_scores, fake_scores)
+        if not torch.isfinite(disc):
+            raise RuntimeError(f"non-finite delta discriminator loss at step {step}")
+        disc.backward()
+        grad_norm = float(
+            torch.nn.utils.clip_grad_norm_(discriminator.parameters(), max_norm=5.0).detach().cpu()
+        )
+        discriminator_optimizer.step()
+
+        decoder_trainer.set_requires_grad(discriminator, False)
+        fake_scores_for_gen, fake_features_for_gen = discriminator(delta_prediction)
+        _real_scores_for_gen, real_features_for_gen = discriminator(delta_target)
+        gen = decoder_trainer.generator_lsgan_loss(fake_scores_for_gen)
+        feat = decoder_trainer.discriminator_feature_matching_loss(
+            real_features_for_gen,
+            fake_features_for_gen,
+        )
+        decoder_trainer.set_requires_grad(discriminator, True)
+        if not torch.isfinite(gen):
+            raise RuntimeError(f"non-finite delta generator adversarial loss at step {step}")
+        if not torch.isfinite(feat):
+            raise RuntimeError(f"non-finite delta adversarial feature loss at step {step}")
+    return gen, feat, disc, gate_mean, grad_norm


### PR DESCRIPTION
## fix: make the published repo's training pipeline runnable

These three files are imported by committed tools but are missing from the published repository (verified: not tracked in git), so `pip install -e .` and the foreign-language porting recipe do not run as-is.

1. **`src/saanotts/models/__init__.py`** — imports `saanotts.models.nirmal_tts`, which is not shipped. The import is now guarded (try/except) and `__all__` is filtered, so the package imports and the present modules (incl. `fsd`, needed by the decoder trainer) load.
2. **`tools/qat_ste.py`** — `train_roota_piper_latent_student.py` does `import qat_ste` and calls `enable_dense_conv1d_qat(model)`, but the file is not in the repo. This is a minimal no-op stand-in so the latent trainer imports.
3. **`tools/train_roota_joint_c_finetune.py`** — `train_roota_joint_z_finetune.py` does `import train_roota_joint_c_finetune as joint_common`. This reconstruction provides the functions by delegating to the present decoder/latent trainers.

Note: these are reconstructions of files that appear to be author-side; the `qat_ste` stub is a no-op and the joint_common is best-effort. Replace with the author's originals if available.